### PR TITLE
Replacing of Short PHP tags with full length tags

### DIFF
--- a/application/views/include/header.php
+++ b/application/views/include/header.php
@@ -9,15 +9,15 @@
 
    <title>CodeIgniter Bootstrap</title>
 
-   <link href="<?= base_url('assets/css/bootstrap.min.css') ?>" rel="stylesheet">
-   <link href="<?= base_url('assets/css/bootstrap-responsive.min.css') ?>" rel="stylesheet">
-	<link href="<?= base_url('assets/css/font-awesome.css') ?>" rel="stylesheet">
-   <link href="<?= base_url('assets/css/style.css') ?>" rel="stylesheet">
-   <link href="<?= base_url('assets/css/custom.css') ?>" rel="stylesheet">
+   <link href="<?php echo base_url('assets/css/bootstrap.min.css') ?>" rel="stylesheet">
+   <link href="<?php echo base_url('assets/css/bootstrap-responsive.min.css') ?>" rel="stylesheet">
+	<link href="<?php echo base_url('assets/css/font-awesome.css') ?>" rel="stylesheet">
+   <link href="<?php echo base_url('assets/css/style.css') ?>" rel="stylesheet">
+   <link href="<?php echo base_url('assets/css/custom.css') ?>" rel="stylesheet">
 
    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
 	<script src="//ajax.googleapis.com/ajax/libs/jqueryui/1.8.18/jquery-ui.min.js"></script>
-   <script src="<?= base_url('assets/js/bootstrap.min.js') ?>"></script>
-	<script src="<?= base_url('assets/js/custom.js') ?>"></script>
+   <script src="<?php echo base_url('assets/js/bootstrap.min.js') ?>"></script>
+	<script src="<?php echo base_url('assets/js/custom.js') ?>"></script>
 </head>
 <body>

--- a/application/views/templates/unit.php
+++ b/application/views/templates/unit.php
@@ -7,22 +7,22 @@
       </tr>
    </thead>
 
-   <? foreach ($tests as $test): ?>
+   <?php foreach ($tests as $test): ?>
       <tr>
-         <td><?= $test['Test Name']; ?></td>
-         <td><?= $test['Notes']; ?></td>
-         <td><span class="label <? if ($test['Result'] == 'Passed'): ?>label-success<? else: ?>label-important<? endif; ?>"><?= $test['Result']; ?></span></td>
+         <td><?php $test['Test Name']; ?></td>
+         <td><?php $test['Notes']; ?></td>
+         <td><span class="label <?php if ($test['Result'] == 'Passed'): ?>label-success<?php else: ?>label-important<?php endif; ?>"><?php $test['Result']; ?></span></td>
       </tr>
-   <? endforeach; ?>
+   <?php endforeach; ?>
 </table>
 
 <div class="row">
-   <? if ($failed > 0): ?>
+   <?php if ($failed > 0): ?>
       <div class="offset3 span5 alert alert-error" style="text-align: center;">
-         <b>Not Good!</b> <?= $failed ?> of <?= $count ?> tests failed! 
-   <? else: ?>
+         <b>Not Good!</b> <?php $failed ?> of <?php $count ?> tests failed! 
+   <?php else: ?>
       <div class="offset3 span5 alert alert-success" style="text-align: center;">
-         <b>Success!</b> Of the <?= $count ?> tests ran, all of them passed!
-   <? endif; ?>
+         <b>Success!</b> Of the <?php $count ?> tests ran, all of them passed!
+   <?php endif; ?>
    </div>
 </div>


### PR DESCRIPTION
Short tags are disabled by default. Its not recommend to use short tags
(<? ?> or <?= ?>). We should use the full length tags (<?php ?>)
