### PR TITLE
Fix broken URLs for clone and FA, bump versions, update docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,11 @@
 ## Version bumps
 
 As much as I love version bump pull requests, they really do not provide any value
-since I have to make a release manually anyways. And lets be honest, its a matter
+since I have to make a release manually anyways. And let's be honest, it's a matter
 of just changing a version number. So please, instead of making these as pull
 requests, just ask through an [issue](https://github.com/sjlu/CodeIgniter-Bootstrap/issues).
 
 ## Worthwhile contributions
 
 * Things that are explicitly broken and fixed are always welcome
-* Code that is worthwile to everyone in [files](https://github.com/sjlu/CodeIgniter-Bootstrap/tree/master/files) 
+* Code that is worthwhile to everyone in [files](https://github.com/sjlu/CodeIgniter-Bootstrap/tree/master/files) 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Bundles the following packages together.
 
 * [CodeIgniter](https://github.com/bcit-ci/CodeIgniter)
 * [CodeIgniter Rest Server](https://github.com/chriskacerguis/codeigniter-restserver)
-* [Twitter Bootstrap](https://github.com/twbs/bootstrap)
+* [Bootstrap](https://github.com/twbs/bootstrap)
 * [Font Awesome](https://github.com/FortAwesome/Font-Awesome)
 * [lodash](https://github.com/lodash/lodash)
 
@@ -14,7 +14,7 @@ Bundles the following packages together.
 
 If you're planning on just using/developing with CodeIgniter Bootstrap, don't clone the repository. Instead, use these steps to get a pre-compiled version of it.
 
-* Download the latest [package](https://github.com/sjlu/CodeIgniter-Bootstrap/releases/download/1.0.3/CodeIgniter-Bootstrap.zip)
+* Download the latest [package](https://github.com/sjlu/CodeIgniter-Bootstrap/releases/download/1.0.4/CodeIgniter-Bootstrap.zip)
     * Or alternatively download another [release](https://github.com/sjlu/CodeIgniter-Bootstrap/releases)
 * Use like any other [CodeIgniter install](http://codeigniter.com/user_guide/installation/index.html)
 
@@ -24,7 +24,7 @@ If you plan on extending the build process, you should follow these steps. This 
 
 * First clone this reposistory
 ```
-git clone git@github.com:sjlu/CodeIgniter-Bootstrap.git
+git clone https://github.com/sjlu/CodeIgniter-Bootstrap.git
 cd CodeIgniter-Bootstrap
 ```
 

--- a/create.sh
+++ b/create.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 set -e
 
-CI_VERSION=3.1.4
-LODASH_VERSION=4.11.0
+CI_VERSION=3.1.7
+LODASH_VERSION=4.17.5
 BOOTSTRAP_VERSION=3.3.7
 FA_VERSION=4.7.0
-CI_REST_VERSION=3.0.0
+CI_REST_VERSION=3.0.3
 
 DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 BUILD_DIR=${DIR}/CodeIgniter-Bootstrap
@@ -40,7 +40,7 @@ mv js/bootstrap.min.js ${BUILD_DIR}/assets/js
 popd
 
 # FONT AWESOME
-wget http://fontawesome.io/assets/font-awesome-${FA_VERSION}.zip -O font-awesome.zip
+wget https://fontawesome.com/v${FA_VERSION}/assets/font-awesome-${FA_VERSION}.zip -O font-awesome.zip
 unzip font-awesome.zip
 pushd font-awesome-${FA_VERSION}
 mv css/* ${BUILD_DIR}/assets/css


### PR DESCRIPTION
Couldn't clone repo from provided URL - updated
Couldn't fetch FA from provided URL - updated
Bump version numbers to most recent version _within major version_
Remove reference to **Twitter** when talking about Bootstrap; it was renamed long ago
Other minor docs clean-up (spelling, etc.)